### PR TITLE
core: throw if directory does not exists

### DIFF
--- a/sqlite.js
+++ b/sqlite.js
@@ -3,6 +3,8 @@
 const async = require('async')
 const SqliteDb = require('sqlite3')
 const Facility = require('./base')
+const path = require('path')
+const fs = require('fs')
 
 class Sqlite extends Facility {
   constructor (caller, opts, ctx) {
@@ -17,8 +19,15 @@ class Sqlite extends Facility {
     async.series([
       next => { super._start(next) },
       next => {
+        const db = `${__dirname}/../../db/${this.name}_${this.opts.name}_${this.opts.label}.db`
+        const dbDir = path.dirname(db)
+
+        if (!fs.existsSync(dbDir)) {
+          throw new Error(`directory ${dbDir} does not exist`)
+        }
+
         this.db = new SqliteDb.Database(
-          `${__dirname}/../../db/${this.name}_${this.opts.name}_${this.opts.label}.db`,
+          db,
           next
         )
       }


### PR DESCRIPTION
previously the service just stopped working / callback was
never called